### PR TITLE
Feat/#29 이미지 신고 내역 조회 구현

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/report/application/ReportService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/report/application/ReportService.java
@@ -2,6 +2,12 @@ package com.prgrms.zzalmyu.domain.report.application;
 
 import com.prgrms.zzalmyu.domain.report.domain.entity.Report;
 import com.prgrms.zzalmyu.domain.report.infrastructure.ReportRepository;
+import com.prgrms.zzalmyu.domain.report.presentation.dto.response.ReportDetailResponse;
+import com.prgrms.zzalmyu.domain.user.application.UserService;
+import com.prgrms.zzalmyu.domain.user.domain.entity.User;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final UserService userService;
 
     public void reportImage(Long userId, Long imageId) {
         Report report = Report.builder()
@@ -19,5 +26,18 @@ public class ReportService {
             .imageId(imageId)
             .build();
         reportRepository.save(report);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReportDetailResponse> getReportDetail(Long imageId) {
+        List<Report> reports = reportRepository.findByImageId(imageId);
+        List<ReportDetailResponse> responses = reports.stream()
+            .map(report -> {
+                User reportUser = userService.findUserById(report.getId());
+                return ReportDetailResponse.of(report, reportUser);
+            })
+            .collect(Collectors.toList());
+
+        return responses;
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/report/infrastructure/ReportRepository.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/report/infrastructure/ReportRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    @Query("select r from Report r where r.imageId = :imageId")
     List<Report> findByImageId(Long imageId);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/report/infrastructure/ReportRepository.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/report/infrastructure/ReportRepository.java
@@ -1,7 +1,13 @@
 package com.prgrms.zzalmyu.domain.report.infrastructure;
 
 import com.prgrms.zzalmyu.domain.report.domain.entity.Report;
+import com.prgrms.zzalmyu.domain.user.domain.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query("select r from Report r where r.imageId = :imageId")
+    List<Report> findByImageId(Long imageId);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/report/presentation/controller/ReportController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/report/presentation/controller/ReportController.java
@@ -1,11 +1,13 @@
 package com.prgrms.zzalmyu.domain.report.presentation.controller;
 
 import com.prgrms.zzalmyu.domain.report.application.ReportService;
+import com.prgrms.zzalmyu.domain.report.presentation.dto.response.ReportDetailResponse;
 import com.prgrms.zzalmyu.domain.user.domain.entity.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,5 +24,11 @@ public class ReportController {
     public ResponseEntity<Void> reportImage(@AuthenticationPrincipal User user, @PathVariable Long imageId) {
         reportService.reportImage(user.getId(), imageId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{imageId}")
+    public ResponseEntity<List<ReportDetailResponse>> getReportedImage(@PathVariable Long imageId) {
+        List<ReportDetailResponse> responses = reportService.getReportDetail(imageId);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/report/presentation/dto/response/ReportDetailResponse.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/report/presentation/dto/response/ReportDetailResponse.java
@@ -1,0 +1,21 @@
+package com.prgrms.zzalmyu.domain.report.presentation.dto.response;
+
+import com.prgrms.zzalmyu.domain.report.domain.entity.Report;
+import com.prgrms.zzalmyu.domain.user.domain.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReportDetailResponse {
+
+    private LocalDateTime reportDate;
+
+    private String reportUserEmail;
+
+    public static ReportDetailResponse of(Report report, User user) {
+        return new ReportDetailResponse(report.getCreatedAt(), user.getEmail());
+    }
+}

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final UserRepository userJPARepository;
     private final JwtService jwtService;
 
     public void logout(String accessToken, String refreshToken) {
@@ -33,8 +32,8 @@ public class UserService {
         user.delete();
     }
 
-    private User findUserById(Long id) {
-        User user = userJPARepository.findById(id)
+    public User findUserById(Long id) {
+        User user = userRepository.findById(id)
             .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
         return user;
     }


### PR DESCRIPTION
## 🚀 개발 사항
이미지 신고 내역 조회 구현
- 신고된 이미지의 신고 일자, 신고자 반환
### 이슈 번호
close

## 📩 특이 사항
- user service의 repository 이름 변경 반영 안 된 부분이 있어 수정했습니다.
- 테스트코드는 추후 s3 사용 가능해지면 작성할 예정입니다.