### PR TITLE
Refact/#32 admin login

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/common/redis/RedisService.java
+++ b/src/main/java/com/prgrms/zzalmyu/common/redis/RedisService.java
@@ -1,4 +1,4 @@
-package com.prgrms.zzalmyu.domain.user.application;
+package com.prgrms.zzalmyu.common.redis;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/prgrms/zzalmyu/core/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/zzalmyu/core/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.prgrms.zzalmyu.core.config;
 
-import com.prgrms.zzalmyu.domain.user.application.RedisService;
+import com.prgrms.zzalmyu.common.redis.RedisService;
 import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
 import com.prgrms.zzalmyu.domain.user.jwt.filter.ExceptionHandlerFilter;
 import com.prgrms.zzalmyu.domain.user.jwt.filter.JwtAuthenticationProcessingFilter;

--- a/src/main/java/com/prgrms/zzalmyu/core/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/zzalmyu/core/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import com.prgrms.zzalmyu.domain.user.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -44,6 +45,7 @@ public class SecurityConfig {
                     SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/h2-console/*").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/report/{imageId}").hasRole("ADMIN")
                 .requestMatchers("/api/v1/user/jwt-test").authenticated()
                 .requestMatchers("/**").permitAll())
             .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
@@ -1,9 +1,9 @@
 package com.prgrms.zzalmyu.domain.user.application;
 
-import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
 import com.prgrms.zzalmyu.core.properties.ErrorCode;
 import com.prgrms.zzalmyu.domain.user.domain.entity.User;
 import com.prgrms.zzalmyu.domain.user.exception.UserException;
+import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
 import com.prgrms.zzalmyu.domain.user.jwt.service.JwtService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/domain/entity/User.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/domain/entity/User.java
@@ -69,7 +69,7 @@ public class User implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.toString()));
+        return List.of(new SimpleGrantedAuthority(role.getKey()));
     }
 
     @Override

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/domain/entity/User.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/domain/entity/User.java
@@ -69,7 +69,7 @@ public class User implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        return List.of(new SimpleGrantedAuthority(role.toString()));
     }
 
     @Override

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,7 +1,7 @@
 package com.prgrms.zzalmyu.domain.user.jwt.filter;
 
+import com.prgrms.zzalmyu.common.redis.RedisService;
 import com.prgrms.zzalmyu.core.properties.ErrorCode;
-import com.prgrms.zzalmyu.domain.user.application.RedisService;
 import com.prgrms.zzalmyu.domain.user.domain.entity.User;
 import com.prgrms.zzalmyu.domain.user.exception.UserException;
 import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
@@ -11,7 +11,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -46,7 +45,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         jwtService.extractRefreshToken(request)
             .ifPresentOrElse(
                 refreshToken -> {
-                    if(jwtService.isTokenValid(refreshToken)) {
+                    if (jwtService.isTokenValid(refreshToken)) {
                         checkRefreshTokenAndReissueAccessToken(response, refreshToken);
                     } else {
                         throw new UserException(ErrorCode.SECURITY_INVALID_TOKEN);

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/service/JwtService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/service/JwtService.java
@@ -3,8 +3,8 @@ package com.prgrms.zzalmyu.domain.user.jwt.service;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.prgrms.zzalmyu.common.redis.RedisService;
 import com.prgrms.zzalmyu.core.properties.ErrorCode;
-import com.prgrms.zzalmyu.domain.user.application.RedisService;
 import com.prgrms.zzalmyu.domain.user.exception.UserException;
 import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -121,7 +121,7 @@ public class JwtService {
         redisService.setValues(accessToken, "logout",
             Duration.ofMillis(accessTokenExpirationPeriod));
     }
-  
+
     private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
         response.setHeader(accessHeader, accessToken);
     }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/CustomOAuth2User.java
@@ -1,5 +1,6 @@
 package com.prgrms.zzalmyu.domain.user.oauth2;
 
+import com.prgrms.zzalmyu.domain.user.domain.enums.Role;
 import java.util.Collection;
 import java.util.Map;
 import lombok.Getter;
@@ -17,6 +18,8 @@ public class CustomOAuth2User extends DefaultOAuth2User {
 
     private String email;
 
+    private Role role;
+
     /**
      * Constructs a {@code DefaultOAuth2User} using the provided parameters.
      *
@@ -28,8 +31,9 @@ public class CustomOAuth2User extends DefaultOAuth2User {
     public CustomOAuth2User(
         Collection<? extends GrantedAuthority> authorities,
         Map<String, Object> attributes, String nameAttributeKey
-        , String email) {
+        , String email, Role role) {
         super(authorities, attributes, nameAttributeKey);
         this.email = email;
+        this.role = role;
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/CustomOAuth2User.java
@@ -18,6 +18,8 @@ public class CustomOAuth2User extends DefaultOAuth2User {
 
     private String email;
 
+    private String nickname;
+
     private Role role;
 
     /**
@@ -31,9 +33,10 @@ public class CustomOAuth2User extends DefaultOAuth2User {
     public CustomOAuth2User(
         Collection<? extends GrantedAuthority> authorities,
         Map<String, Object> attributes, String nameAttributeKey
-        , String email, Role role) {
+        , String email, String nickname, Role role) {
         super(authorities, attributes, nameAttributeKey);
         this.email = email;
+        this.nickname = nickname;
         this.role = role;
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/LoginSuccessResponse.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/LoginSuccessResponse.java
@@ -12,9 +12,12 @@ public class LoginSuccessResponse {
 
     private Role role;
 
-    public static LoginSuccessResponse of(String email, Role role) {
+    private String nickname;
+
+    public static LoginSuccessResponse of(String email, String nickname, Role role) {
         return LoginSuccessResponse.builder()
             .email(email)
+                .nickname(nickname)
             .role(role)
             .build();
     }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/LoginSuccessResponse.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/LoginSuccessResponse.java
@@ -1,0 +1,21 @@
+package com.prgrms.zzalmyu.domain.user.oauth2;
+
+import com.prgrms.zzalmyu.domain.user.domain.enums.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginSuccessResponse {
+
+    private String email;
+
+    private Role role;
+
+    public static LoginSuccessResponse of(String email, Role role) {
+        return LoginSuccessResponse.builder()
+            .email(email)
+            .role(role)
+            .build();
+    }
+}

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,12 +1,17 @@
 package com.prgrms.zzalmyu.domain.user.oauth2.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.zzalmyu.domain.user.jwt.service.JwtService;
 import com.prgrms.zzalmyu.domain.user.oauth2.CustomOAuth2User;
+import com.prgrms.zzalmyu.domain.user.oauth2.LoginSuccessResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -18,8 +23,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtService jwtService;
 
-    private static final String BEARER = "Bearer ";
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) throws IOException, ServletException {
@@ -29,11 +32,16 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtService.createAccessToken(email);
         String refreshToken = jwtService.createRefreshToken();
 
-        //accessToken, refreshToken 발급하고 /home으로 리다이렉트하도록 응답 보내기
+        //accessToken, refreshToken을 헤더에 넣고, 응답 dto 구성
+        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(email, oAuth2User.getRole());
         jwtService.sendAccessTokenAndRefreshToken(response, accessToken, refreshToken);
-        response.sendRedirect("/home");
 
         // redis의 리프레시 토큰 새로 발급한 리프레시 토큰으로 갱신
         jwtService.updateRefreshToken(refreshToken, email);
+
+        //응답 보내기
+        response.setStatus(HttpStatus.OK.value());
+        response.getWriter().print(new ObjectMapper().writeValueAsString(loginSuccessResponse));
+        response.getWriter().flush();
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -10,8 +10,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -33,7 +31,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String refreshToken = jwtService.createRefreshToken();
 
         //accessToken, refreshToken을 헤더에 넣고, 응답 dto 구성
-        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(email, oAuth2User.getRole());
+        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(email,
+            oAuth2User.getRole());
         jwtService.sendAccessTokenAndRefreshToken(response, accessToken, refreshToken);
 
         // redis의 리프레시 토큰 새로 발급한 리프레시 토큰으로 갱신

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -31,7 +31,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String refreshToken = jwtService.createRefreshToken();
 
         //accessToken, refreshToken을 헤더에 넣고, 응답 dto 구성
-        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(email,
+        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(email, oAuth2User.getNickname(),
             oAuth2User.getRole());
         jwtService.sendAccessTokenAndRefreshToken(response, accessToken, refreshToken);
 

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
@@ -53,7 +53,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             // Collections.singleton() : 단일 항목으로 갖는 컬렉션 생성
             attributes,
             oAuthDto.getNameAttributeKey(),
-            user.getEmail()
+            user.getEmail(),
+            user.getRole()
         );
         // CustomOAuth2User로 고고
     }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
@@ -64,7 +64,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
      */
     private User getUser(OAuthDto oAuthDto, SocialType socialType) {
         OAuth2UserInfo oAuth2UserInfo = oAuthDto.getOAuth2UserInfo();
-        User findUser = userRepository.findBySocialTypeAndSocialId(socialType, oAuth2UserInfo.getId())
+        User findUser = userRepository.findBySocialTypeAndSocialId(socialType,
+                oAuth2UserInfo.getId())
             .orElseGet(() -> saveUser(oAuthDto, socialType, oAuth2UserInfo));
 
         return findUser;

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
@@ -54,6 +54,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             attributes,
             oAuthDto.getNameAttributeKey(),
             user.getEmail(),
+            user.getNickname(),
             user.getRole()
         );
         // CustomOAuth2User로 고고


### PR DESCRIPTION
## 🚀 개발 사항
- admin login 관련해 수정 사항 반영했습니다.
- 로그인 완료 시 로그인 완료한 사용자의 email, role을 응답에 담아 반환하도록 구현했습니다.

### admin 권한 api 테스트 방법
1. 노션에 알려준 방법으로 소셜로그인을 합니다.
2. user_tb에 저장된 나의 정보에서 social id를 확인합니다.
3. 이 사용자 정보를 user_tb에서 삭제합니다.
4. db에 
`INSERT INTO user_tb (created_at, email, nickname, role, social_type, social_id) VALUES (NOW(), '이메일', '닉네임', 'ADMIN', 'NAVER', '2에서 확인한 social id');`
이런 형식으로 관리자 정보를 저장해줍니다.
5. 1과 같이 소셜로그인을 하고, 응답 헤더에 있는 accessToken을 복사합니다.
6. postman에서 요청 헤더에 5에서 복사한 accessToken을 넣고 `http://localhost:8080/api/v1/report/1` get 요청을 보냅니다.
7. 현재 아무 정보가 없기 때문에 빈 리스트가 뜨면 성공입니다. 실패 시 403 forbidden(접근 권한 없음) 에러가 뜹니다.

### 이슈 번호
close

## 📩 특이 사항
- common 패키지 만들고 redisservice 넣었습니다!