### PR TITLE
[FIX] kakao 로그인 오류 수정

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -40,6 +40,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         //응답 보내기
         response.setStatus(HttpStatus.OK.value());
+        response.setCharacterEncoding("UTF-8");
         response.getWriter().print(new ObjectMapper().writeValueAsString(loginSuccessResponse));
         response.getWriter().flush();
     }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -76,8 +76,8 @@ public class KakaoOAuth2UserInfo extends
 
     @Override
     public String getEmail() {
-        Map<String, Object> profile = getProfile();
-        return (String) profile.get("email");
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        return (String) account.get("email");
     }
 
     private Map<String, Object> getProfile() {


### PR DESCRIPTION
## 🚀 개발 사항
- 카카오 서버에서 email 가져오는 함수 수정
- 로그인 성공 시 한글 깨지는 문제로 utf-8 인코딩 설정(클라에서도 해줘야함)
### 이슈 번호
close

## 📩 특이 사항
- application.properties 에서 naver, kakao 프로필 사진 가져오기 취소