### PR TITLE
[FIX] 카카오 이메일 중복 문제 해결

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/oauth2/service/CustomOAuth2UserService.java
@@ -65,8 +65,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
      */
     private User getUser(OAuthDto oAuthDto, SocialType socialType) {
         OAuth2UserInfo oAuth2UserInfo = oAuthDto.getOAuth2UserInfo();
-        User findUser = userRepository.findBySocialTypeAndSocialId(socialType,
-                oAuth2UserInfo.getId())
+        User findUser = userRepository.findByEmail(oAuth2UserInfo.getEmail())
             .orElseGet(() -> saveUser(oAuthDto, socialType, oAuth2UserInfo));
 
         return findUser;


### PR DESCRIPTION
## 🚀 개발 사항
- 카카오 로그인에서도 naver, google 이메일을 사용하는데, 이 때문에 같은 이메일 계정이어도 다른 유저로 취급되어 findByEmail 시 두 계정 반환하는 문제 해결
- 다른 소셜로 로그인해도 이메일 같으면 같은 유저로 취급
### 이슈 번호
close

## 📩 특이 사항
