### PR TITLE
Feat/#146 좋아요/업로드한 이미지 태그 필터링 기능 수정

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/image/application/ImageSearchService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/image/application/ImageSearchService.java
@@ -1,6 +1,5 @@
 package com.prgrms.zzalmyu.domain.image.application;
 
-import com.prgrms.zzalmyu.domain.image.presentation.dto.req.TagSearchRequestDto;
 import com.prgrms.zzalmyu.domain.image.presentation.dto.res.AwsS3ResponseDto;
 import com.prgrms.zzalmyu.domain.user.domain.entity.User;
 
@@ -12,11 +11,11 @@ public interface ImageSearchService {
      * 좋아요한 짤 태그 필터링
      *
      */
-    List<AwsS3ResponseDto> searchLikeImages(User user, TagSearchRequestDto tagSearchRequestDto);
+    List<AwsS3ResponseDto> searchLikeImages(User user, List<String> tagNames);
 
     /**
      * 업로드한 짤 태그 필터링
      *
      */
-    List<AwsS3ResponseDto> searchUploadImages(User user, TagSearchRequestDto tagSearchRequestDto);
+    List<AwsS3ResponseDto> searchUploadImages(User user, List<String> tagNames);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/image/infrastructure/ImageTagRepositoryImpl.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/image/infrastructure/ImageTagRepositoryImpl.java
@@ -22,6 +22,8 @@ public class ImageTagRepositoryImpl implements ImageTagRepositoryCustom {
                 .join(imageLike).on(imageLike.image.eq(image))
                 .where(imageLike.user.id.eq(userId))
                 .where(imageTag.tag.id.in(tagIdList))
+                .groupBy(image)
+                .having(imageTag.tag.id.countDistinct().eq(Long.valueOf(tagIdList.size())))
                 .fetch();
     }
 
@@ -29,8 +31,10 @@ public class ImageTagRepositoryImpl implements ImageTagRepositoryCustom {
     public List<Image> findUploadImagesByUserIdAndTagIdList(Long userId, List<Long> tagIdList) {
         return queryFactory.selectFrom(image)
                 .join(imageTag).on(imageTag.image.eq(image))
-                .where(image.userId.eq(userId),
-                        imageTag.tag.id.in(tagIdList))
+                .where(image.userId.eq(userId))
+                .where(imageTag.tag.id.in(tagIdList))
+                .groupBy(image)
+                .having(imageTag.tag.id.countDistinct().eq(Long.valueOf(tagIdList.size())))
                 .fetch();
     }
 

--- a/src/main/java/com/prgrms/zzalmyu/domain/image/presentation/controller/ImageController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/image/presentation/controller/ImageController.java
@@ -2,7 +2,6 @@ package com.prgrms.zzalmyu.domain.image.presentation.controller;
 
 import com.prgrms.zzalmyu.domain.image.application.*;
 import com.prgrms.zzalmyu.domain.image.presentation.dto.req.ImageUploadRequestDto;
-import com.prgrms.zzalmyu.domain.image.presentation.dto.req.TagSearchRequestDto;
 import com.prgrms.zzalmyu.domain.image.presentation.dto.res.AwsS3ResponseDto;
 import com.prgrms.zzalmyu.domain.image.presentation.dto.res.ImageDetailResponse;
 import com.prgrms.zzalmyu.domain.image.presentation.dto.res.ImageResponseDto;
@@ -60,15 +59,15 @@ public class ImageController {
     }
 
     @ApiResponse(description = "좋아요 누른 짤 페이지에서 태그 검색")
-    @PostMapping("/me/like")
-    List<AwsS3ResponseDto> searchLikeImages(@AuthenticationPrincipal User user, @RequestBody TagSearchRequestDto dto) {
-        return imageSearchService.searchLikeImages(user, dto);
+    @GetMapping("/me/like")
+    List<AwsS3ResponseDto> searchLikeImages(@AuthenticationPrincipal User user, @RequestParam(name = "tagName") List<String> tagNames) {
+        return imageSearchService.searchLikeImages(user, tagNames);
     }
 
     @ApiResponse(description = "업로드한 짤 페이지에서 태그 검색")
-    @PostMapping("/me/upload")
-    List<AwsS3ResponseDto> searchUploadImages(@AuthenticationPrincipal User user, @RequestBody TagSearchRequestDto dto) {
-        return imageSearchService.searchUploadImages(user, dto);
+    @GetMapping("/me/upload")
+    List<AwsS3ResponseDto> searchUploadImages(@AuthenticationPrincipal User user, @RequestParam(name = "tagName") List<String> tagNames) {
+        return imageSearchService.searchUploadImages(user, tagNames);
     }
 
     @ApiResponse(description = "짤 업로드")

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/application/TagService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/application/TagService.java
@@ -47,4 +47,7 @@ public interface TagService {
     String splitTagName(String tagName);
 
     List<TagResponseDto> getRecommendationTags(User user);
+
+    // 태그 사용 횟수 증가
+    TagResponseDto increaseTagCount(User user, String newTagName);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepository.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long>, TagRepositoryCustom {
     boolean existsByName(String name);
+    Optional<Tag> findByName(String name);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepositoryCustom.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepositoryCustom.java
@@ -15,4 +15,5 @@ public interface TagRepositoryCustom {
     List<TagResponseDto> searchTagForAutoSearchNameFromLikeImages(Long userId, String inputString);
     List<TagResponseDto> searchTagForAutoSearchNameFromUploadImages(Long userId, String inputString);
     List<TagResponseDto> getRecommendationTags(User user);
+    List<Long> findTagIdListByTagNameList(List<String> tagNameList);
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepositoryCustomImpl.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/infrastructure/TagRepositoryCustomImpl.java
@@ -137,4 +137,12 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                 .limit(5)
                 .fetch();
     }
+
+    @Override
+    public List<Long> findTagIdListByTagNameList(List<String> tagNameList) {
+        return queryFactory.select(tag.id)
+                .from(tag)
+                .where(tag.name.in(tagNameList))
+                .fetch();
+    }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/presentation/controller/TagController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/presentation/controller/TagController.java
@@ -70,4 +70,10 @@ public class TagController {
     public List<TagResponseDto> searchTagFromUploadImages(@AuthenticationPrincipal User user, @RequestParam String keyword) {
         return tagService.searchTagFromUploadImages(user, keyword);
     }
+
+    @ApiResponse(description = "태그 사용 횟수 증가")
+    @PostMapping("/use")
+    public TagResponseDto increaseTagCount(@AuthenticationPrincipal User user, @RequestParam String newTagName) {
+        return tagService.increaseTagCount(user, newTagName);
+    }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/tag/presentation/dto/res/TagResponseDto.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/tag/presentation/dto/res/TagResponseDto.java
@@ -1,6 +1,7 @@
 package com.prgrms.zzalmyu.domain.tag.presentation.dto.res;
 
 import com.prgrms.zzalmyu.domain.tag.domain.entity.Tag;
+import com.prgrms.zzalmyu.domain.tag.domain.entity.TagUser;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,14 @@ public class TagResponseDto {
 
     public TagResponseDto(Tag tag) {
         this(tag.getId(), tag.getName());
+    }
+
+    public static TagResponseDto from(Tag tag, TagUser tagUser) {
+        return TagResponseDto.builder()
+                .tagId(tag.getId())
+                .tagName(tag.getName())
+                .count(tagUser.getCount())
+                .build();
     }
 
 }

--- a/src/test/java/com/prgrms/zzalmyu/domain/image/infrastructure/ImageTagRepositoryTest.java
+++ b/src/test/java/com/prgrms/zzalmyu/domain/image/infrastructure/ImageTagRepositoryTest.java
@@ -1,0 +1,224 @@
+package com.prgrms.zzalmyu.domain.image.infrastructure;
+
+import com.prgrms.zzalmyu.domain.chat.domain.entity.ImageChatCount;
+import com.prgrms.zzalmyu.domain.chat.infrastructure.ImageChatCountRepository;
+import com.prgrms.zzalmyu.domain.image.domain.entity.Image;
+import com.prgrms.zzalmyu.domain.image.domain.entity.ImageLike;
+import com.prgrms.zzalmyu.domain.image.domain.entity.ImageTag;
+import com.prgrms.zzalmyu.domain.tag.domain.entity.Tag;
+import com.prgrms.zzalmyu.domain.tag.infrastructure.TagRepository;
+import com.prgrms.zzalmyu.domain.user.domain.entity.User;
+import com.prgrms.zzalmyu.domain.user.domain.enums.Role;
+import com.prgrms.zzalmyu.domain.user.domain.enums.SocialType;
+import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ImageTagRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    ImageRepository imageRepository;
+    @Autowired
+    ImageTagRepository imageTagRepository;
+    @Autowired
+    ImageChatCountRepository imageChatCountRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    ImageLikeRepository imageLikeRepository;
+
+    Long userId;
+    Long userId2;
+    User user;
+    User user1;
+    Tag tag1;
+    Tag tag2;
+    Tag tag3;
+    Tag tag4;
+    @BeforeEach
+    void init() {
+        user = User.builder()
+                .email("sss9073@naver.com")
+                .role(Role.USER)
+                .socialId("socialId")
+                .socialType(SocialType.GOOGLE)
+                .nickname("nickname").build();
+        userRepository.save(user);
+        user1 = User.builder()
+                .email("user1@naver.com")
+                .role(Role.USER)
+                .socialId("socialId")
+                .socialType(SocialType.GOOGLE)
+                .nickname("nickname").build();
+        userRepository.save(user);
+        userRepository.save(user1);
+        userId = user.getId();
+        userId2 = user1.getId();
+        tag1 = Tag.from("토끼");
+        tag2 = Tag.from("고양이");
+        tag3 = Tag.from("강아지");
+        tag4 = Tag.from("안유진");
+        tagRepository.save(tag1);
+        tagRepository.save(tag2);
+        tagRepository.save(tag3);
+        tagRepository.save(tag4);
+
+    }
+
+    @DisplayName("업로드한 이미지에서 태그 id 리스트에 다 일치하는 이미지를 반환한다.")
+    @Test
+    void findUploadImagesByUserIdAndTagIdListTest(){
+        //Given
+        Image image1 = Image.builder()
+                .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                .userId(userId)
+                .s3Key("s3key")
+                .title("title1")
+                .path("path")
+                .build();
+        Image image2 = Image.builder()
+                .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                .userId(userId)
+                .s3Key("s3key")
+                .title("title2")
+                .path("path")
+                .build();
+        Image image3 = Image.builder()
+                .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                .userId(userId2)
+                .s3Key("s3key")
+                .title("title3")
+                .path("path")
+                .build();
+        imageRepository.save(image1);
+        imageRepository.save(image2);
+        imageRepository.save(image3);
+        ImageTag imageTag1 = ImageTag.builder()
+                .tag(tag1)
+                .image(image1)
+                .build();
+        ImageTag imageTag2 = ImageTag.builder()
+                .tag(tag2)
+                .image(image1)
+                .build();
+        // 같은 유저이지만 태그가 다름
+        ImageTag imageTag3 = ImageTag.builder()
+                .tag(tag2)
+                .image(image2)
+                .build();
+        ImageTag imageTag4 = ImageTag.builder()
+                .tag(tag3)
+                .image(image2)
+                .build();
+        // 태그는 같지만 다른 유저
+        ImageTag imageTag5 = ImageTag.builder()
+                .tag(tag1)
+                .image(image3)
+                .build();
+        ImageTag imageTag6 = ImageTag.builder()
+                .tag(tag2)
+                .image(image3)
+                .build();
+        imageTagRepository.save(imageTag1);
+        imageTagRepository.save(imageTag2);
+        imageTagRepository.save(imageTag3);
+        imageTagRepository.save(imageTag4);
+        imageTagRepository.save(imageTag5);
+        imageTagRepository.save(imageTag6);
+
+        //When
+        List<Long> tagIdList = List.of(tag1.getId(), tag2.getId());
+        List<Image> imageResultList = imageTagRepository.findUploadImagesByUserIdAndTagIdList(userId, tagIdList);
+        //Then
+        assertThat(imageResultList).hasSize(1);
+        assertThat(imageResultList.get(0).getTitle()).isEqualTo(image1.getTitle());
+     }
+
+     @DisplayName("좋아요한 이미지에서 태그 id 리스트에 다 일치하는 이미지를 반환한다.")
+     @Test
+     void findLikeImagesByUserIdAndTagIdListTest(){
+         //Given
+         Image image1 = Image.builder()
+                 .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                 .userId(userId)
+                 .s3Key("s3key")
+                 .title("title1")
+                 .path("path")
+                 .build();
+         Image image2 = Image.builder()
+                 .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                 .userId(userId)
+                 .s3Key("s3key")
+                 .title("title2")
+                 .path("path")
+                 .build();
+         Image image3 = Image.builder()
+                 .imageChatCount(imageChatCountRepository.save(new ImageChatCount()))
+                 .userId(userId2)
+                 .s3Key("s3key")
+                 .title("title3")
+                 .path("path")
+                 .build();
+         imageRepository.save(image1);
+         imageRepository.save(image2);
+         imageRepository.save(image3);
+         ImageTag imageTag1 = ImageTag.builder()
+                 .tag(tag1)
+                 .image(image1)
+                 .build();
+         ImageTag imageTag2 = ImageTag.builder()
+                 .tag(tag2)
+                 .image(image1)
+                 .build();
+         // 같은 유저이지만 태그가 다름
+         ImageTag imageTag3 = ImageTag.builder()
+                 .tag(tag2)
+                 .image(image2)
+                 .build();
+         ImageTag imageTag4 = ImageTag.builder()
+                 .tag(tag3)
+                 .image(image2)
+                 .build();
+         // 태그는 같지만 다른 유저
+         ImageTag imageTag5 = ImageTag.builder()
+                 .tag(tag1)
+                 .image(image3)
+                 .build();
+         ImageTag imageTag6 = ImageTag.builder()
+                 .tag(tag2)
+                 .image(image3)
+                 .build();
+         imageTagRepository.save(imageTag1);
+         imageTagRepository.save(imageTag2);
+         imageTagRepository.save(imageTag3);
+         imageTagRepository.save(imageTag4);
+         imageTagRepository.save(imageTag5);
+         imageTagRepository.save(imageTag6);
+
+         ImageLike imageLike = ImageLike
+                 .builder()
+                 .user(user1)
+                 .image(image1)
+                 .build();
+         imageLikeRepository.save(imageLike);
+         //When
+         List<Long> tagIdList = List.of(tag1.getId(), tag2.getId());
+         List<Image> likeImageResult = imageTagRepository.findLikeImagesByUserIdAndTagIdList(user1.getId(), tagIdList);
+         //Then
+         assertThat(likeImageResult).hasSize(1);
+         assertThat(likeImageResult.get(0).getTitle()).isEqualTo(image1.getTitle());
+      }
+
+}


### PR DESCRIPTION
## 🚀 개발 사항
프론트 요청사항에 따라, GET 및 param으로 태그이름들을 받아서 필터링하는 걸 수정했습니다.
또 query가 조금 이상한 부분이 있어서 이거 해결했습니다.
### 이슈 번호
close #146 

## 📩 특이 사항
메인 이미지 태그 필터링은 용상이가 해주시는데, 쿼리 코드 짜시는거 제거 참고하셔서 하세요..!
