### PR TITLE
[REFACTOR] 시큐리티 로직 수정

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -44,11 +44,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                 .ifPresent(accessToken -> {
                     if(!jwtService.isTokenValid(accessToken)) { //accessToken 만료 시
                         throw new UserException(ErrorCode.SECURITY_INVALID_ACCESS_TOKEN);
-                    } else {
-                        checkAccessTokenAndSaveAuthentication(request, response, filterChain);
                     }
                 });
-        filterChain.doFilter(request, response);
+        checkAccessTokenAndSaveAuthentication(request, response, filterChain);
     }
 
     private void checkLogout(HttpServletRequest request) {


### PR DESCRIPTION
## 🚀 개발 사항
- 로직을 변경했습니다.

1. 클라이언트가 accessToken을 헤더에 넣어 요청한다.
2. 클라이언트에서 1차적으로 토큰 유효성 검사 후, 만료되었으면 서버에 리프레시 토큰을 헤더에 담아 재발급을 요청합니다.
3. 서버는 리프레시 토큰과 액세스 토큰을 새로 발급해 헤더에 넣어 보내줍니다.
4. 클라이언트는 받은 토큰들을 로컬 스토리지에 저장하고, 새로 발급 받은 accessToken을 헤더에 넣고 요청합니다.
### 이슈 번호
close

## 📩 특이 사항
