### PR TITLE
Refactor/#157 reissue

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/core/properties/ErrorCode.java
+++ b/src/main/java/com/prgrms/zzalmyu/core/properties/ErrorCode.java
@@ -26,11 +26,14 @@ public enum ErrorCode {
     IMAGE_DELETION_NOT_ALLOWED(BAD_REQUEST, "신고가 3번 이상 누적되어야 이미지를 삭제할 수 있습니다."),
     TAG_NOT_FOUND_ERROR(BAD_REQUEST, "해당 태그가 존재하지 않습니다,"),
     TAG_ALREADY_EXIST_ERROR(BAD_REQUEST, "해당하는 태그가 이미 존재합니다."),
+    REFRESH_TOKEN_REQUIRED(BAD_REQUEST, "refresh token이 필요합니다."),
 
 
     // 401
     SECURITY_UNAUTHORIZED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다"),
     SECURITY_INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    SECURITY_INVALID_REFRESH_TOKEN(UNAUTHORIZED, "refresh token이 유효하지 않습니다."),
+    SECURITY_INVALID_ACCESS_TOKEN(UNAUTHORIZED, "access token이 유효하지 않습니다."),
     SOCIAL_LOGIN_FAIL(UNAUTHORIZED, "소셜 로그인에 실패했습니다."),
 
     // 403

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/application/UserService.java
@@ -5,6 +5,8 @@ import com.prgrms.zzalmyu.domain.user.domain.entity.User;
 import com.prgrms.zzalmyu.domain.user.exception.UserException;
 import com.prgrms.zzalmyu.domain.user.infrastructure.UserRepository;
 import com.prgrms.zzalmyu.domain.user.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,9 +15,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Transactional
 public class UserService {
-
     private final UserRepository userRepository;
     private final JwtService jwtService;
+
+    public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtService.extractRefreshToken(request)
+                .orElseThrow(() -> new UserException(ErrorCode.REFRESH_TOKEN_REQUIRED));
+        jwtService.isTokenValid(refreshToken);
+
+        jwtService.reissueAndSendTokens(response, refreshToken);
+    }
 
     public void logout(String accessToken, String refreshToken) {
         jwtService.isTokenValid(refreshToken);

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -42,11 +42,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                 .ifPresent(accessToken -> {
                     if(!jwtService.isTokenValid(accessToken)) { //accessToken 만료 시
                         throw new UserException(ErrorCode.SECURITY_INVALID_ACCESS_TOKEN);
-                    } else {
-                        checkAccessTokenAndSaveAuthentication(request, response, filterChain);
                     }
                 });
-        filterChain.doFilter(request, response);
+        checkAccessTokenAndSaveAuthentication(request, response, filterChain);
     }
 
     private void checkLogout(HttpServletRequest request) {

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -18,81 +19,50 @@ import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMap
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 @RequiredArgsConstructor
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
-
     private final JwtService jwtService;
     private final RedisService redisService;
     private final UserRepository userRepository;
-
-    private static String NOT_EXIST = "false";
 
     private static String NO_CHECK_URL = "/api/v1/user/logout";
 
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain) throws ServletException, IOException {
+                                    FilterChain filterChain) throws ServletException, IOException {
         if (request.getRequestURI().equals(NO_CHECK_URL)) {
             filterChain.doFilter(request, response);
             return;
         }
         checkLogout(request); //로그아웃한 사용자면 인증 처리 안함
 
-        jwtService.extractRefreshToken(request)
-            .ifPresentOrElse(
-                refreshToken -> {
-                    if (jwtService.isTokenValid(refreshToken)) {
-                        checkRefreshTokenAndReissueAccessToken(response, refreshToken);
+        jwtService.extractAccessToken(request)
+                .ifPresent(accessToken -> {
+                    if(!jwtService.isTokenValid(accessToken)) { //accessToken 만료 시
+                        throw new UserException(ErrorCode.SECURITY_INVALID_ACCESS_TOKEN);
                     } else {
-                        throw new UserException(ErrorCode.SECURITY_INVALID_TOKEN);
+                        checkAccessTokenAndSaveAuthentication(request, response, filterChain);
                     }
-                },
-                () -> checkAccessTokenAndAuthentication(request, response, filterChain)
-            );
+                });
+        filterChain.doFilter(request, response);
     }
 
     private void checkLogout(HttpServletRequest request) {
         jwtService.extractAccessToken(request).ifPresent(accessToken -> {
             String value = redisService.getValues(accessToken);
-
             if (value.equals("logout")) {
                 throw new UserException(ErrorCode.SECURITY_UNAUTHORIZED);
             }
         });
     }
 
-    private void checkRefreshTokenAndReissueAccessToken(HttpServletResponse response,
-        String refreshToken) {
-        String email = findRefreshTokenAndExtractEmail(refreshToken);
-        String reissuedRefreshToken = reissueRefreshToken(email);
-        jwtService.sendAccessTokenAndRefreshToken(response, jwtService.createAccessToken(email),
-            reissuedRefreshToken);
-    }
-
-    private String findRefreshTokenAndExtractEmail(String refreshToken) {
-        String email = redisService.getValues(refreshToken);
-
-        if (email.equals(NOT_EXIST)) {
-            throw new UserException(ErrorCode.SECURITY_INVALID_TOKEN);
-        }
-        return email;
-    }
-
-    private String reissueRefreshToken(String email) {
-        String reissuedRefreshToken = jwtService.createRefreshToken();
-        jwtService.updateRefreshToken(reissuedRefreshToken, email);
-        return reissuedRefreshToken;
-    }
-
-    private void checkAccessTokenAndAuthentication(HttpServletRequest request,
-        HttpServletResponse response, FilterChain filterChain) {
+    private void checkAccessTokenAndSaveAuthentication(HttpServletRequest request,
+                                                       HttpServletResponse response, FilterChain filterChain) {
         jwtService.extractAccessToken(request)
-            .filter(jwtService::isTokenValid).flatMap(jwtService::extractEmail)
-            .flatMap(userRepository::findByEmail).ifPresent(this::saveAuthentication);
+                .flatMap(jwtService::extractEmail)
+                .flatMap(userRepository::findByEmail).ifPresent(this::saveAuthentication);
 
         try {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/service/JwtService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/jwt/service/JwtService.java
@@ -41,72 +41,64 @@ public class JwtService {
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
     private static final String EMAIL_CLAIM = "email";
     private static final String BEARER = "Bearer ";
+    private static final String NOT_EXIST = "false";
 
     private final UserRepository userRepository;
     private final RedisService redisService;
-
     public String createAccessToken(String email) {
         Date now = new Date();
-
         return JWT.create()
-            .withSubject(ACCESS_TOKEN_SUBJECT)
-            .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
-            .withClaim(EMAIL_CLAIM, email)
-            .sign(Algorithm.HMAC512(secretKey));
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey));
     }
-
     public String createRefreshToken() {
         Date now = new Date();
         return JWT.create()
-            .withSubject(REFRESH_TOKEN_SUBJECT)
-            .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
-            .sign(Algorithm.HMAC512(secretKey));
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
     }
 
-    public void sendAccessTokenAndRefreshToken(HttpServletResponse response, String accessToken,
-        String refreshToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
-
-        setAccessTokenHeader(response, BEARER + accessToken);
-        setRefreshTokenHeader(response, BEARER + refreshToken);
+    public String reissueRefreshToken(String email) {
+        String reissuedRefreshToken = createRefreshToken();
+        updateRefreshToken(reissuedRefreshToken, email);
+        return reissuedRefreshToken;
     }
 
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(refreshHeader))
-            .filter(refreshToken -> refreshToken.startsWith(BEARER))
-            .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
     }
-
     public Optional<String> extractAccessToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(accessHeader))
-            .filter(accessToken -> accessToken.startsWith(BEARER))
-            .map(accessToken -> accessToken.replace(BEARER, ""));
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
     }
-
     public Optional<String> extractEmail(String accessToken) {
         try {
             return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
-                .build()
-                .verify(accessToken) //검증
-                .getClaim(EMAIL_CLAIM) //추출
-                .asString());
+                    .build()
+                    .verify(accessToken) //검증
+                    .getClaim(EMAIL_CLAIM) //추출
+                    .asString());
         } catch (JWTVerificationException e) {
             throw new UserException(ErrorCode.SECURITY_UNAUTHORIZED);
         }
     }
-
     //RefreshToken redis 저장
     public void updateRefreshToken(String refreshToken, String email) {
         redisService.setValues(refreshToken, email,
-            Duration.ofMillis(refreshTokenExpirationPeriod));
+                Duration.ofMillis(refreshTokenExpirationPeriod));
     }
-
     public boolean isTokenValid(String token) {
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (JWTVerificationException e) {
-            throw new UserException(ErrorCode.SECURITY_UNAUTHORIZED);
+            return false;
         }
     }
 
@@ -116,17 +108,30 @@ public class JwtService {
         }
         redisService.delete(refreshToken);
     }
-
     public void logoutAccessToken(String accessToken) {
         redisService.setValues(accessToken, "logout",
-            Duration.ofMillis(accessTokenExpirationPeriod));
+                Duration.ofMillis(accessTokenExpirationPeriod));
     }
 
-    private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
-        response.setHeader(accessHeader, accessToken);
+    public String findRefreshTokenAndExtractEmail(String refreshToken) {
+        String email = redisService.getValues(refreshToken);
+
+        if (email.equals(NOT_EXIST)) {
+            throw new UserException(ErrorCode.SECURITY_INVALID_REFRESH_TOKEN);
+        }
+        return email;
     }
 
-    private void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
-        response.setHeader(refreshHeader, refreshToken);
+    private void sendTokens(HttpServletResponse response, String reissuedAccessToken, String reissuedRefreshToken) {
+        response.setHeader(accessHeader, BEARER + reissuedAccessToken);
+        response.setHeader(refreshHeader, BEARER + reissuedRefreshToken);
+    }
+
+    public void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {
+        String email = findRefreshTokenAndExtractEmail(refreshToken);
+        String reissuedRefreshToken = reissueRefreshToken(email);
+        String reissuedAccessToken = createAccessToken(email);
+
+        sendTokens(response, reissuedAccessToken, reissuedRefreshToken);
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/user/presentation/controller/UserController.java
@@ -5,6 +5,7 @@ import com.prgrms.zzalmyu.domain.user.domain.entity.User;
 import com.prgrms.zzalmyu.domain.user.jwt.service.JwtService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,10 +15,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
 public class UserController {
-
     private final UserService userService;
     private final JwtService jwtService;
 
+    @ApiResponse(description = "토큰 재발급 요청")
+    @PostMapping("/reissue")
+    public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
+        userService.reissueTokens(request, response);
+    }
     @ApiResponse(description = "로그아웃")
     @PatchMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request) {


### PR DESCRIPTION
## 🚀 개발 사항
- 로직을 변경했습니다.

1. 클라이언트가 accessToken을 헤더에 넣어 요청한다.
2. 클라이언트에서 1차적으로 토큰 유효성 검사 후, 만료되었으면 서버에 리프레시 토큰을 헤더에 담아 재발급을 요청합니다.
3. 서버는 리프레시 토큰과 액세스 토큰을 새로 발급해 헤더에 넣어 보내줍니다.
4. 클라이언트는 받은 토큰들을 로컬 스토리지에 저장하고, 새로 발급 받은 accessToken을 헤더에 넣고 요청합니다.
### 이슈 번호
close

## 📩 특이 사항
