### PR TITLE
[FEAT] 채팅 내역 저장, 불러오기 구현

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/domain/entity/ChatMessage.java
@@ -1,0 +1,41 @@
+package com.prgrms.zzalmyu.domain.chat.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@Table(name = "chat_message_TB")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String message;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private ChatMessage(String nickname, String message) {
+        this.nickname = nickname;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/infrastructure/ChatMessageRepository.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/infrastructure/ChatMessageRepository.java
@@ -1,0 +1,14 @@
+package com.prgrms.zzalmyu.domain.chat.infrastructure;
+
+import com.prgrms.zzalmyu.domain.chat.domain.entity.ChatMessage;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatOldMessageResponse;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    @Query("select c from ChatMessage c")
+    List<ChatMessage> findForOneDay(Pageable pageable);
+}

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/controller/ChatController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/controller/ChatController.java
@@ -1,34 +1,24 @@
 package com.prgrms.zzalmyu.domain.chat.presentation.controller;
 
 import com.prgrms.zzalmyu.domain.chat.application.ChatService;
-import com.prgrms.zzalmyu.domain.chat.presentation.dto.req.ChatHelloRequest;
-import com.prgrms.zzalmyu.domain.chat.presentation.dto.req.ChatPhotoRequest;
-import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatHelloResponse;
-import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatImageResponse;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatOldMessageResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.stereotype.Controller;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
-@Slf4j
+@RequestMapping("/api/v1/chat")
 public class ChatController {
 
-    private final SimpMessageSendingOperations simpMessageSendingOperations;
     private final ChatService chatService;
 
-    @MessageMapping("/hello")
-    public void greeting(ChatHelloRequest request) {
-        String nickname = chatService.generateNickname();
-        chatService.saveNickname(request.getEmail(), nickname);
-        simpMessageSendingOperations.convertAndSend("/sub/" + request.getChannelId(), ChatHelloResponse.of(request.getEmail(), nickname));
-    }
-
-    @MessageMapping("/image")
-    public void sendPhoto(ChatPhotoRequest request) {
-        String nickname = chatService.getNickname(request.getEmail());
-        simpMessageSendingOperations.convertAndSend("/sub/" + request.getChannelId(), ChatImageResponse.of(request.getEmail(), request.getImage(), nickname));
+    @GetMapping
+    public List<ChatOldMessageResponse> getOldChats(@PageableDefault(size = 5) Pageable pageable) {
+        return chatService.getOldChats(pageable);
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/controller/WebSocketController.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/controller/WebSocketController.java
@@ -1,0 +1,41 @@
+package com.prgrms.zzalmyu.domain.chat.presentation.controller;
+
+import com.prgrms.zzalmyu.domain.chat.application.ChatService;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.req.ChatHelloRequest;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.req.ChatPhotoRequest;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatHelloResponse;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatImageResponse;
+import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatOldMessageResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketController {
+
+    private final SimpMessageSendingOperations simpMessageSendingOperations;
+    private final ChatService chatService;
+
+    @MessageMapping("/hello")
+    public void greeting(ChatHelloRequest request) {
+        String nickname = chatService.generateNickname();
+        chatService.saveNickname(request.getEmail(), nickname);
+        String message = chatService.saveMessage(nickname);
+        simpMessageSendingOperations.convertAndSend("/sub/" + request.getChannelId(), ChatHelloResponse.of(request.getEmail(), nickname, message));
+    }
+
+    @MessageMapping("/image")
+    public void sendPhoto(ChatPhotoRequest request) {
+        String nickname = chatService.getNickname(request.getEmail());
+        chatService.saveMessage(nickname, request.getImage());
+        simpMessageSendingOperations.convertAndSend("/sub/" + request.getChannelId(), ChatImageResponse.of(request.getEmail(), request.getImage(), nickname));
+    }
+}

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/dto/res/ChatHelloResponse.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/dto/res/ChatHelloResponse.java
@@ -10,8 +10,7 @@ public class ChatHelloResponse {
     private String nickname;
     private String message;
 
-    public static ChatHelloResponse of(String email, String nickname) {
-        String message = nickname + "님이 입장하셨습니다.";
+    public static ChatHelloResponse of(String email, String nickname, String message) {
         return new ChatHelloResponse(email, nickname, message);
     }
 }

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/dto/res/ChatOldMessageResponse.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/presentation/dto/res/ChatOldMessageResponse.java
@@ -1,0 +1,24 @@
+package com.prgrms.zzalmyu.domain.chat.presentation.dto.res;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatOldMessageResponse {
+
+    private String nickname;
+
+    private String message;
+
+    private LocalDateTime createdAt;
+
+    public static ChatOldMessageResponse of(String nickname, String message, LocalDateTime createdAt) {
+        return ChatOldMessageResponse.builder()
+            .nickname(nickname)
+            .message(message)
+            .createdAt(createdAt)
+            .build();
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
- 채팅 내용 저장 및 불러오기
- 방금 들어온 사용자도 이전 채팅을 볼 수 있음

### 이슈 번호
close

## 📩 특이 사항
- 스케줄러를 이용한 삭제는 나중에 구현
- chat_message_tb 테이블 추가