### PR TITLE
[FIX] 더이상 불러올 채팅 내역 없을 때 예외 처리

### DIFF
--- a/src/main/java/com/prgrms/zzalmyu/core/properties/ErrorCode.java
+++ b/src/main/java/com/prgrms/zzalmyu/core/properties/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_REQUIRED(BAD_REQUEST, "refresh token이 필요합니다."),
     EMAIL_NOT_EXTRACTED(BAD_REQUEST, "이메일을 추출할 수 없습니다."),
     CHAT_NICKNAME_NOT_FOUND(BAD_REQUEST, "이메일에 매칭되는 채팅 닉네임이 존재하지 않습니다."),
+    NO_MORE_CHAT_MESSAGE(BAD_REQUEST, "더 이상 채팅 내역이 없습니다."),
 
     // 401
     SECURITY_UNAUTHORIZED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다"),

--- a/src/main/java/com/prgrms/zzalmyu/domain/chat/application/ChatService.java
+++ b/src/main/java/com/prgrms/zzalmyu/domain/chat/application/ChatService.java
@@ -3,6 +3,7 @@ package com.prgrms.zzalmyu.domain.chat.application;
 import com.prgrms.zzalmyu.common.redis.RedisService;
 import com.prgrms.zzalmyu.core.properties.ErrorCode;
 import com.prgrms.zzalmyu.domain.chat.domain.entity.ChatMessage;
+import com.prgrms.zzalmyu.domain.chat.exception.ChatException;
 import com.prgrms.zzalmyu.domain.chat.infrastructure.ChatMessageRepository;
 import com.prgrms.zzalmyu.domain.chat.presentation.dto.req.ChatNameRequest;
 import com.prgrms.zzalmyu.domain.chat.presentation.dto.res.ChatNameResponse;
@@ -72,14 +73,19 @@ public class ChatService {
 
     @Transactional(readOnly = true)
     public List<ChatOldMessageResponse> getOldChats(Pageable pageable) {
-        return chatMessageRepository.findAllByLatest(pageable)
-                .stream()
-                .map(message -> ChatOldMessageResponse.of(
-                        message.getNickname(),
-                        message.getMessage(),
-                        message.getCreatedAt(),
-                        message.getEmail()
-                ))
-                .collect(Collectors.toList());
+        List<ChatOldMessageResponse> response = chatMessageRepository.findAllByLatest(pageable)
+            .stream()
+            .map(message -> ChatOldMessageResponse.of(
+                message.getNickname(),
+                message.getMessage(),
+                message.getCreatedAt(),
+                message.getEmail()
+            ))
+            .collect(Collectors.toList());
+
+        if(response.isEmpty()) {
+            throw new ChatException(ErrorCode.NO_MORE_CHAT_MESSAGE);
+        }
+        return response;
     }
 }


### PR DESCRIPTION
## 🚀 개발 사항
- 더이상 페이지네이션에 내용이 없어도 계속 빈 응답이 날아가는 문제 발생
- 채팅 내역 불러오는 페이지네이션 시 더이상 불러올 데이터 없으면 예외 처리
### 이슈 번호
close

## 📩 특이 사항
